### PR TITLE
ARM: dts: 15801: Correct TP vdd min voltage

### DIFF
--- a/arch/arm/boot/dts/qcom/15801/msm8996-mtp.dtsi
+++ b/arch/arm/boot/dts/qcom/15801/msm8996-mtp.dtsi
@@ -1902,7 +1902,7 @@
 	qcom,init-voltage = <1100000>;
 };
 &pm8994_l13 {
-	regulator-min-microvolt = <29500000>;
+	regulator-min-microvolt = <2950000>;
 };
 &pm8994_l14 {
 	status = "disabled";


### PR DESCRIPTION
 * oneplus preduce shits everywhere
 * https://github.com/OnePlusOSS/android_kernel_oneplus_msm8996/blob/oneplus/QC8996_N/arch/arm64/boot/dts/15801_PVT/msm8996-regulator.dtsi#L219

Change-Id: I49aa8e8fe645447e981d301b3e55e03975e4c461